### PR TITLE
Feature/features conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,14 @@ Dialplan methods
   * play_time
   * play_numeric
   * play_soundfile
+  * enable_feature
+  * disable_feature
 
 Asterisk configuration generators
 
   * agents.conf
   * queues.conf
   * voicemail.conf
-
-### TODO
-
-  * Asterisk dynamic features (aka. features.conf)
 
 Requirements
 ------------
@@ -88,6 +86,13 @@ salesagent {
 supportagent {
   queue('support').join!
 }
+
+operator {
+  enable_feature :blind_transfer
+  dial extension, :options => "Tt"
+}
+
+
 ```
 
 ### Config generation

--- a/spec/adhearsion/asterisk/plugin_spec.rb
+++ b/spec/adhearsion/asterisk/plugin_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Adhearsion::Asterisk
   describe 'A DialPlan::ExecutionEnvironment with the plugin loaded' do
-    before(:all) { Adhearsion::Plugin.load }
+    before(:all) { Adhearsion::Plugin.load_plugins }
 
     let(:mock_call) { stub_everything 'Call', :originating_voip_platform => :punchblock }
 


### PR DESCRIPTION
Code review requested and merge if ready.

Specs:

All test are passing.

I could not figure out how to remove the existing hack for not mocking Hash# with the test lambda so I just adjusted it to work with Mocha.

Code:

enable/disable_feature are dialplan methods.

I do not think extend_dynamic_features_with() should be defined as a normally seen method, but that seems to be the only way to make it available in the same namespace w/o some ugly direct Module/Class specification for the definition.
