### PR TITLE
[FEATURE] Add generate_silence helper

### DIFF
--- a/lib/adhearsion/asterisk/call_controller_methods.rb
+++ b/lib/adhearsion/asterisk/call_controller_methods.rb
@@ -413,8 +413,6 @@ module Adhearsion
       end
 
       class GenerateSilenceProxy
-        delegate :respond_to?, :to => :@_target
-
         def self.proxy_for(target, &block)
           proxy = new(target)
           ivs = target.instance_variables
@@ -434,6 +432,10 @@ module Adhearsion
           @_target.send(*args).tap do
             @_target.generate_silence
           end
+        end
+
+        def respond_to_missing?(*args)
+          @_target.respond_to?(*args)
         end
       end
     end

--- a/lib/adhearsion/asterisk/call_controller_methods.rb
+++ b/lib/adhearsion/asterisk/call_controller_methods.rb
@@ -413,6 +413,8 @@ module Adhearsion
       end
 
       class GenerateSilenceProxy
+        delegate :respond_to?, :to => :@_target
+
         def self.proxy_for(target, &block)
           proxy = new(target)
           ivs = target.instance_variables

--- a/spec/adhearsion/asterisk/call_controller_methods_spec.rb
+++ b/spec/adhearsion/asterisk/call_controller_methods_spec.rb
@@ -493,6 +493,40 @@ module Adhearsion::Asterisk
           subject.play_soundfile(audiofile).should == false
         end
       end
+
+      describe '#generate_silence' do
+        context 'executes Playtones with 0 as an argument if it' do
+          before do
+            command = Punchblock::Component::Asterisk::AGI::Command.new :name => "EXEC Playtones", :params => ["0"]
+            @expect_command = subject.expects(:execute_component_and_await_completion).with(command)
+          end
+
+          it 'is not given a block' do
+            @expect_command.once
+            subject.generate_silence
+          end
+
+          it 'is given a block, which it then yields' do
+            @expect_command.times(3)
+            expect { |b| subject.generate_silence { b.to_proc.call; run; run } }.to yield_with_no_args
+          end
+
+          it 'is given a block, and copies any instance variables' do
+            @expect_command.once
+
+            iv = nil
+            subject.instance_variable_set(:@foo, "bar")
+
+            subject.generate_silence do
+              iv = @foo.dup
+              @foo << "baz"
+            end
+
+            iv.should eq("bar")
+            subject.instance_variable_get(:@foo).should eq("barbaz")
+          end
+        end
+      end
     end
   end#main describe
 end

--- a/spec/adhearsion/asterisk/call_controller_methods_spec.rb
+++ b/spec/adhearsion/asterisk/call_controller_methods_spec.rb
@@ -525,6 +525,21 @@ module Adhearsion::Asterisk
             iv.should eq("bar")
             subject.instance_variable_get(:@foo).should eq("barbaz")
           end
+
+          it 'is given a block, which proxies any calls to #respond_to?' do
+            @expect_command.once
+
+            run_result = nil
+            foobar_result = nil
+
+            subject.generate_silence do
+              run_result = respond_to? :run
+              foobar_result = respond_to? :foobar
+            end
+
+            run_result.should be_true
+            foobar_result.should be_false
+          end
         end
       end
     end

--- a/spec/adhearsion/asterisk/call_controller_methods_spec.rb
+++ b/spec/adhearsion/asterisk/call_controller_methods_spec.rb
@@ -526,7 +526,7 @@ module Adhearsion::Asterisk
             subject.instance_variable_get(:@foo).should eq("barbaz")
           end
 
-          it 'is given a block, which proxies any calls to #respond_to?' do
+          it 'is given a block, which proxies calls to #respond_to? via #respond_to_missing?' do
             @expect_command.once
 
             run_result = nil


### PR DESCRIPTION
I needed this for use with ChanSpy but there could potentially be other uses too. I'll probably go to hell for the instance_eval stuff but it was Ben Langfeld's idea and I couldn't think of anything better. (-;
