### PR TITLE
Set PUNCHBLOCK_END_ON_ASYNCAGI_BREAK to force channel release on Goto ex...

### DIFF
--- a/lib/adhearsion/asterisk/call_controller_methods.rb
+++ b/lib/adhearsion/asterisk/call_controller_methods.rb
@@ -421,6 +421,7 @@ module Adhearsion
         call[:ahn_prevent_hangup] = true
         args = ['Goto', context, extension, priority].reject { |v| v == :nothing }
         execute *args
+        set_variable 'PUNCHBLOCK_END_ON_ASYNCAGI_BREAK', 'true'
         agi "ASYNCAGI BREAK"
       end
 


### PR DESCRIPTION
...ecution

The new PUNCHBLOCK_END_ON_ASYNCAGI_BREAK variable needs to be set when issuing a Goto.
