### PR TITLE
Feature/set end on async break

### DIFF
--- a/lib/adhearsion/asterisk/call_controller_methods.rb
+++ b/lib/adhearsion/asterisk/call_controller_methods.rb
@@ -421,6 +421,7 @@ module Adhearsion
         call[:ahn_prevent_hangup] = true
         args = ['Goto', context, extension, priority].reject { |v| v == :nothing }
         execute *args
+        set_variable 'PUNCHBLOCK_END_ON_ASYNCAGI_BREAK', 'true'
         agi "ASYNCAGI BREAK"
       end
 

--- a/spec/adhearsion/asterisk/call_controller_methods_spec.rb
+++ b/spec/adhearsion/asterisk/call_controller_methods_spec.rb
@@ -21,10 +21,10 @@ module Adhearsion::Asterisk
           end
         end
 
-        before { Punchblock::Component::Asterisk::AGI::Command.any_instance.stubs :complete_event => complete_event }
+        before { Punchblock::Component::Asterisk::AGI::Command.any_instance.stub :complete_event => complete_event }
 
         it 'should execute an AGI command with the specified name and parameters and return the response code, response and data' do
-          subject.expects(:execute_component_and_await_completion).once.with expected_agi_command
+          subject.should_receive(:execute_component_and_await_completion).once.with expected_agi_command
           values = subject.agi 'Dial', '4044754842', 15
           values.should == [200, 1, 'foobar']
         end
@@ -37,7 +37,7 @@ module Adhearsion::Asterisk
           end
 
           it 'should raise Adhearsion::Call::Hangup' do
-            subject.expects(:execute_component_and_await_completion).once.with expected_agi_command
+            subject.should_receive(:execute_component_and_await_completion).once.with expected_agi_command
             lambda { subject.agi 'Dial', '4044754842', 15 }.should raise_error(Adhearsion::Call::Hangup)
           end
         end
@@ -45,21 +45,21 @@ module Adhearsion::Asterisk
 
       describe '#execute' do
         it 'calls #agi and prefixes the command with EXEC' do
-          subject.expects(:agi).once.with 'EXEC Dial', '4044754842,15'
+          subject.should_receive(:agi).once.with 'EXEC Dial', '4044754842,15'
           subject.execute 'Dial', '4044754842', 15
         end
       end
 
       describe '#verbose' do
         it 'executes the VERBOSE AGI command' do
-          subject.expects(:agi).once.with 'VERBOSE', 'Foo Bar!', 15
+          subject.should_receive(:agi).once.with 'VERBOSE', 'Foo Bar!', 15
           subject.verbose 'Foo Bar!', 15
         end
       end
 
       describe '#enable_feature' do
         it 'it should fetch the variable for DYNAMIC_FEATURES at first' do
-          subject.expects(:variable).once.with("DYNAMIC_FEATURES").throws(:got_variable)
+          subject.should_receive(:variable).once.with("DYNAMIC_FEATURES").and_throw(:got_variable)
           expect {
             subject.enable_feature :foobar
           }.to throw_symbol :got_variable
@@ -75,13 +75,13 @@ module Adhearsion::Asterisk
 
           # I had to do this ugly hack because of a bug in Flexmock which prevented me from mocking out Hash#[]  :(
           # FIXME: mock Hash
-          #        ...DYNAMIC_FEATURE_EXTENSIONS.expects(feature_name => assertion)
+          #        ...DYNAMIC_FEATURE_EXTENSIONS.should_receive(feature_name => assertion)
 
           old_hash_feature_extension = Adhearsion::Asterisk::CallControllerMethods::DYNAMIC_FEATURE_EXTENSIONS[feature_name]
           begin
             Adhearsion::Asterisk::CallControllerMethods::DYNAMIC_FEATURE_EXTENSIONS[feature_name] = assertion
 
-            subject.expects(:enable_feature).once.with(feature_name, :this_is_the_right_arg).throws :inside_assertion!
+            subject.should_receive(:enable_feature).once.with(feature_name, :this_is_the_right_arg).and_throw :inside_assertion!
             expect { subject.enable_feature(feature_name, :this_is_the_right_arg)}.to throw_symbol :inside_assertion!
           ensure
             Adhearsion::Asterisk::CallControllerMethods::DYNAMIC_FEATURE_EXTENSIONS[feature_name] = old_hash_feature_extension
@@ -89,13 +89,13 @@ module Adhearsion::Asterisk
         end
 
         it 'should separate enabled features with a "#"' do
-          subject.expects(:variable).once.with("DYNAMIC_FEATURES").returns("one")
-          subject.expects(:variable).once.with("DYNAMIC_FEATURES" => 'one#bar')
+          subject.should_receive(:variable).once.with("DYNAMIC_FEATURES").and_return("one")
+          subject.should_receive(:variable).once.with("DYNAMIC_FEATURES" => 'one#bar')
           subject.enable_feature "bar"
         end
 
         it 'should not add duplicate enabled dynamic features' do
-          subject.expects(:variable).once.returns('eins#zwei')
+          subject.should_receive(:variable).once.and_return('eins#zwei')
           subject.enable_feature "eins"
         end
 
@@ -106,63 +106,63 @@ module Adhearsion::Asterisk
         end
 
         it 'enabling :attended_transfer should actually enable the atxfer feature' do
-          subject.expects(:variable).once.with("DYNAMIC_FEATURES").returns ''
-          subject.expects(:variable).once.with("DYNAMIC_FEATURES" => 'atxfer')
+          subject.should_receive(:variable).once.with("DYNAMIC_FEATURES").and_return ''
+          subject.should_receive(:variable).once.with("DYNAMIC_FEATURES" => 'atxfer')
           subject.enable_feature :attended_transfer
         end
 
         it 'the :context optional option when enabling :attended_transfer should set the TRANSFER_CONTEXT variable to the String supplied as a Hash value' do
           context_name = "direct_dial"
-          subject.expects(:variable).once.with("DYNAMIC_FEATURES").returns ''
-          subject.expects(:variable).once.with("DYNAMIC_FEATURES" => 'atxfer')
-          subject.expects(:variable).once.with("TRANSFER_CONTEXT" => context_name)
+          subject.should_receive(:variable).once.with("DYNAMIC_FEATURES").and_return ''
+          subject.should_receive(:variable).once.with("DYNAMIC_FEATURES" => 'atxfer')
+          subject.should_receive(:variable).once.with("TRANSFER_CONTEXT" => context_name)
           subject.enable_feature :attended_transfer, :context => context_name
         end
 
         it 'enabling :attended_transfer should not add a duplicate if atxfer has been enabled, but it should still set the TRANSFER_CONTEXT variable' do
           context_name = 'blah'
-          subject.expects(:variable).once.with('DYNAMIC_FEATURES').returns 'atxfer'
-          subject.expects(:variable).once.with('TRANSFER_CONTEXT' => context_name)
+          subject.should_receive(:variable).once.with('DYNAMIC_FEATURES').and_return 'atxfer'
+          subject.should_receive(:variable).once.with('TRANSFER_CONTEXT' => context_name)
           subject.enable_feature :attended_transfer, :context => context_name
         end
       end
 
       describe '#disable_feature' do
         it "should properly remove the feature from the DYNAMIC_FEATURES variable" do
-          subject.expects(:variable).once.with('DYNAMIC_FEATURES').returns 'foobar#qaz'
-          subject.expects(:variable).once.with('DYNAMIC_FEATURES' => 'qaz')
+          subject.should_receive(:variable).once.with('DYNAMIC_FEATURES').and_return 'foobar#qaz'
+          subject.should_receive(:variable).once.with('DYNAMIC_FEATURES' => 'qaz')
           subject.disable_feature "foobar"
         end
 
         it "should not re-set the variable if the feature wasn't enabled in the first place" do
-          subject.expects(:variable).once.with('DYNAMIC_FEATURES').returns 'atxfer'
-          subject.expects(:variable).never
+          subject.should_receive(:variable).once.with('DYNAMIC_FEATURES').and_return 'atxfer'
+          subject.should_receive(:variable).never
           subject.disable_feature "jay"
         end
       end
 
       describe "#variable" do
         it "should call set_variable when Hash argument given" do
-          subject.expects(:set_variable).once.with :ohai, "ur_home_erly"
+          subject.should_receive(:set_variable).once.with :ohai, "ur_home_erly"
           subject.variable :ohai => 'ur_home_erly'
         end
 
         it "should call set_variable for every Hash-key given" do
           many_args = { :a => :b, :c => :d, :e => :f, :g => :h}
-          subject.expects(:set_variable).times(many_args.size)
+          subject.should_receive(:set_variable).exactly(many_args.size).times
           subject.variable many_args
         end
 
         it "should call get_variable for every String given" do
           variables = ["foo", "bar", :qaz, :qwerty, :baz]
           variables.each do |var|
-            subject.expects(:get_variable).once.with(var).returns("X")
+            subject.should_receive(:get_variable).once.with(var).and_return("X")
           end
           subject.variable(*variables).should == ["X"] * variables.size
         end
 
         it "should NOT return an Array when just one arg is given" do
-          subject.expects(:get_variable).once.returns "lol"
+          subject.should_receive(:get_variable).once.and_return "lol"
           subject.variable(:foo).should_not be_a Array
         end
 
@@ -175,21 +175,21 @@ module Adhearsion::Asterisk
 
       describe "#set_variable" do
         it "uses SET VARIABLE" do
-          subject.expects(:agi).once.with 'SET VARIABLE', 'foo', 'i can " has ruby?'
+          subject.should_receive(:agi).once.with 'SET VARIABLE', 'foo', 'i can " has ruby?'
           subject.set_variable 'foo', 'i can " has ruby?'
         end
       end
 
       describe '#get_variable' do
         it 'uses GET VARIABLE and extracts the value from the data' do
-          subject.expects(:agi).once.with('GET VARIABLE', 'foo').returns [200, 1, 'bar']
+          subject.should_receive(:agi).once.with('GET VARIABLE', 'foo').and_return [200, 1, 'bar']
           subject.get_variable('foo').should == 'bar'
         end
       end
 
       describe "#sip_add_header" do
         it "executes SIPAddHeader" do
-          subject.expects(:execute).once.with 'SIPAddHeader', 'x-ahn-header: rubyrox'
+          subject.should_receive(:execute).once.with 'SIPAddHeader', 'x-ahn-header: rubyrox'
           subject.sip_add_header "x-ahn-header", "rubyrox"
         end
       end
@@ -197,7 +197,7 @@ module Adhearsion::Asterisk
       describe "#sip_get_header" do
         it "uses #get_variable to get the header value" do
           value = 'jason-was-here'
-          subject.expects(:get_variable).once.with('SIP_HEADER(x-ahn-header)').returns value
+          subject.should_receive(:get_variable).once.with('SIP_HEADER(x-ahn-header)').and_return value
           subject.sip_get_header("x-ahn-header").should == value
         end
       end
@@ -205,25 +205,25 @@ module Adhearsion::Asterisk
       describe '#join' do
         it "should pass the 'd' flag when no options are given" do
           conference_id = "123"
-          subject.expects(:execute).once.with("MeetMe", conference_id, "d", nil)
+          subject.should_receive(:execute).once.with("MeetMe", conference_id, "d", nil)
           subject.meetme conference_id
         end
 
         it "should pass through any given flags with 'd' appended to it if necessary" do
           conference_id, flags = "1000", "zomgs"
-          subject.expects(:execute).once.with("MeetMe", conference_id, flags + "d", nil)
+          subject.should_receive(:execute).once.with("MeetMe", conference_id, flags + "d", nil)
           subject.meetme conference_id, :options => flags
         end
 
         it "should NOT pass the 'd' flag when requiring static conferences" do
           conference_id, options = "1000", {:use_static_conf => true}
-          subject.expects(:execute).once.with("MeetMe", conference_id, "", nil)
+          subject.should_receive(:execute).once.with("MeetMe", conference_id, "", nil)
           subject.meetme conference_id, options
         end
 
         it "should raise an ArgumentError when the pin is not numerical" do
           lambda {
-            subject.expects(:execute).never
+            subject.should_receive(:execute).never
             subject.meetme 3333, :pin => "letters are bad, mkay?!1"
           }.should raise_error ArgumentError
         end
@@ -231,7 +231,7 @@ module Adhearsion::Asterisk
         it "should strip out illegal characters from a conference name" do
           bizarre_conference_name = "a-    bc!d&&e--`"
           normal_conference_name = "abcde"
-          subject.expects(:execute).twice.with("MeetMe", normal_conference_name, "d", nil)
+          subject.should_receive(:execute).twice.with("MeetMe", normal_conference_name, "d", nil)
 
           subject.meetme bizarre_conference_name
           subject.meetme normal_conference_name
@@ -239,7 +239,7 @@ module Adhearsion::Asterisk
 
         it "should allow textual conference names" do
           lambda {
-            subject.expects(:execute).once
+            subject.should_receive(:execute).once
             subject.meetme "david bowie's pants"
           }.should_not raise_error
         end
@@ -247,28 +247,28 @@ module Adhearsion::Asterisk
 
       describe '#voicemail' do
         it 'should not send the context name when none is given' do
-          subject.expects(:execute).once.with('voicemail', 123, '').throws :sent_voicemail!
+          subject.should_receive(:execute).once.with('voicemail', 123, '').and_throw :sent_voicemail!
           lambda { subject.voicemail 123 }.should throw_symbol(:sent_voicemail!)
         end
 
         it 'should send the context name when one is given' do
           mailbox_number, context_name = 333, 'doesntmatter'
-          subject.expects(:execute).once.with('voicemail', "#{mailbox_number}@#{context_name}", '').throws :sent_voicemail!
+          subject.should_receive(:execute).once.with('voicemail', "#{mailbox_number}@#{context_name}", '').and_throw :sent_voicemail!
           lambda { subject.voicemail(context_name => mailbox_number) }.should throw_symbol(:sent_voicemail!)
         end
 
         it 'should pass in the s option if :skip => true' do
           mailbox_number = '012'
-          subject.expects(:execute).once.with('voicemail', mailbox_number, 's').throws :sent_voicemail!
+          subject.should_receive(:execute).once.with('voicemail', mailbox_number, 's').and_throw :sent_voicemail!
           lambda { subject.voicemail(mailbox_number, :skip => true) }.should throw_symbol(:sent_voicemail!)
         end
 
         it 'should combine mailbox numbers with the context name given when both are given' do
-          subject.expects(:variable).with("VMSTATUS").returns 'SUCCESS'
+          subject.should_receive(:variable).with("VMSTATUS").and_return 'SUCCESS'
           context   = "lolcats"
           mailboxes = [1,2,3,4,5]
           mailboxes_with_context = mailboxes.map { |mailbox| [mailbox, context].join '@' }
-          subject.expects(:execute).once.with('voicemail', mailboxes_with_context.join('&'), '')
+          subject.should_receive(:execute).once.with('voicemail', mailboxes_with_context.join('&'), '')
           subject.voicemail context => mailboxes
         end
 
@@ -298,13 +298,13 @@ module Adhearsion::Asterisk
 
         it 'should pass in the u option if :greeting => :unavailable' do
           mailbox_number = '776'
-          subject.expects(:execute).once.with('voicemail', mailbox_number, 'u').throws :sent_voicemail!
+          subject.should_receive(:execute).once.with('voicemail', mailbox_number, 'u').and_throw :sent_voicemail!
           lambda { subject.voicemail(mailbox_number, :greeting => :unavailable) }.should throw_symbol(:sent_voicemail!)
         end
 
         it 'should pass in both the skip and greeting options if both are supplied' do
           mailbox_number = '4'
-          subject.expects(:execute).once.with('voicemail', mailbox_number, 'u').throws :sent_voicemail!
+          subject.should_receive(:execute).once.with('voicemail', mailbox_number, 'u').and_throw :sent_voicemail!
           lambda { subject.voicemail(mailbox_number, :greeting => :unavailable) }.should throw_symbol(:sent_voicemail!)
         end
 
@@ -320,25 +320,25 @@ module Adhearsion::Asterisk
 
         it 'should pass in the b option if :gretting => :busy' do
           mailbox_number = '1'
-          subject.expects(:execute).once.with('voicemail', mailbox_number, 'b').throws :sent_voicemail!
+          subject.should_receive(:execute).once.with('voicemail', mailbox_number, 'b').and_throw :sent_voicemail!
           lambda { subject.voicemail(mailbox_number, :greeting => :busy) }.should throw_symbol(:sent_voicemail!)
         end
 
         it 'should return true if VMSTATUS == "SUCCESS"' do
-          subject.expects(:execute).once
-          subject.expects(:variable).once.with('VMSTATUS').returns "SUCCESS"
+          subject.should_receive(:execute).once
+          subject.should_receive(:variable).once.with('VMSTATUS').and_return "SUCCESS"
           subject.voicemail(3).should be true
         end
 
         it 'should return false if VMSTATUS == "USEREXIT"' do
-          subject.expects(:execute).once
-          subject.expects(:variable).once.with('VMSTATUS').returns "USEREXIT"
+          subject.should_receive(:execute).once
+          subject.should_receive(:variable).once.with('VMSTATUS').and_return "USEREXIT"
           subject.voicemail(2).should be false
         end
 
         it 'should return nil if VMSTATUS == "FAILED"' do
-          subject.expects(:execute).once
-          subject.expects(:variable).once.with('VMSTATUS').returns "FAILED"
+          subject.should_receive(:execute).once
+          subject.should_receive(:variable).once.with('VMSTATUS').and_return "FAILED"
           subject.voicemail(2).should be nil
         end
       end
@@ -347,48 +347,48 @@ module Adhearsion::Asterisk
         it "the :folder Hash key argument should wrap the value in a()" do
           folder = "foobar"
           mailbox = 81
-          subject.expects(:execute).once.with("VoiceMailMain", "#{mailbox}","a(#{folder})")
+          subject.should_receive(:execute).once.with("VoiceMailMain", "#{mailbox}","a(#{folder})")
           subject.voicemail_main :mailbox => mailbox, :folder => folder
         end
 
         it ':authenticate should pass in the "s" option if given false' do
           mailbox = 333
-          subject.expects(:execute).once.with("VoiceMailMain", "#{mailbox}","s")
+          subject.should_receive(:execute).once.with("VoiceMailMain", "#{mailbox}","s")
           subject.voicemail_main :mailbox => mailbox, :authenticate => false
         end
 
         it ':authenticate should pass in the s option if given false' do
           mailbox = 55
-          subject.expects(:execute).once.with("VoiceMailMain", "#{mailbox}")
+          subject.should_receive(:execute).once.with("VoiceMailMain", "#{mailbox}")
           subject.voicemail_main :mailbox => mailbox, :authenticate => true
         end
 
         it 'should not pass any flags only a mailbox is given' do
           mailbox = "1"
-          subject.expects(:execute).once.with("VoiceMailMain", "#{mailbox}")
+          subject.should_receive(:execute).once.with("VoiceMailMain", "#{mailbox}")
           subject.voicemail_main :mailbox => mailbox
         end
 
         it 'when given no mailbox or context an empty string should be passed to execute as the first argument' do
-          subject.expects(:execute).once.with("VoiceMailMain", "", "s")
+          subject.should_receive(:execute).once.with("VoiceMailMain", "", "s")
           subject.voicemail_main :authenticate => false
         end
 
         it 'should properly concatenate the options when given multiple ones' do
           folder = "ohai"
           mailbox = 9999
-          subject.expects(:execute).once.with("VoiceMailMain", "#{mailbox}", "sa(#{folder})")
+          subject.should_receive(:execute).once.with("VoiceMailMain", "#{mailbox}", "sa(#{folder})")
           subject.voicemail_main :mailbox => mailbox, :authenticate => false, :folder => folder
         end
 
         it 'should not require any arguments' do
-          subject.expects(:execute).once.with("VoiceMailMain")
+          subject.should_receive(:execute).once.with("VoiceMailMain")
           subject.voicemail_main
         end
 
         it 'should pass in the "@context_name" part in if a :context is given and no mailbox is given' do
           context_name = "icanhascheezburger"
-          subject.expects(:execute).once.with("VoiceMailMain", "@#{context_name}")
+          subject.should_receive(:execute).once.with("VoiceMailMain", "@#{context_name}")
           subject.voicemail_main :context => context_name
         end
 
@@ -427,17 +427,17 @@ module Adhearsion::Asterisk
         let(:time_format) { 'IMp' }
 
         it "if a Date object is passed in, SayUnixTime is sent with the argument and format" do
-          subject.expects(:execute).once.with("SayUnixTime", date.to_time.to_i, "", date_format)
+          subject.should_receive(:execute).once.with("SayUnixTime", date.to_time.to_i, "", date_format)
           subject.play_time(date, :format => date_format)
         end
 
         it "if a Time object is passed in, SayUnixTime is sent with the argument and format" do
-          subject.expects(:execute).once.with("SayUnixTime", time.to_i, "", time_format)
+          subject.should_receive(:execute).once.with("SayUnixTime", time.to_i, "", time_format)
           subject.play_time(time, :format => time_format)
         end
 
         it "if a Time object is passed in alone, SayUnixTime is sent with the argument and the default format" do
-          subject.expects(:execute).once.with("SayUnixTime", time.to_i, "", "")
+          subject.should_receive(:execute).once.with("SayUnixTime", time.to_i, "", "")
           subject.play_time(time)
         end
 
@@ -446,7 +446,7 @@ module Adhearsion::Asterisk
       describe "#play_numeric" do
         let(:numeric) { 20 }
         it "should send the correct command SayNumber playing a numeric argument" do
-          subject.expects(:execute).once.with("SayNumber", numeric)
+          subject.should_receive(:execute).once.with("SayNumber", numeric)
           subject.play_numeric(numeric)
         end
       end
@@ -454,7 +454,7 @@ module Adhearsion::Asterisk
       describe "#play_digits" do
         let(:numeric) { 20 }
         it "should send the correct command SayDigits playing a numeric argument" do
-          subject.expects(:execute).once.with("SayDigits", numeric)
+          subject.should_receive(:execute).once.with("SayDigits", numeric)
           subject.play_digits(numeric)
         end
       end
@@ -462,7 +462,7 @@ module Adhearsion::Asterisk
       describe "#play_tones" do
         context "should send the correct command Playtones playing tones" do
           before do
-            subject.expects(:execute).once.with("Playtones", "!950/330,!1400/330,!1800/330,0")
+            subject.should_receive(:execute).once.with("Playtones", "!950/330,!1400/330,!1800/330,0")
           end
 
           it "given as a string" do
@@ -474,7 +474,7 @@ module Adhearsion::Asterisk
           end
 
           it "and sleep for the duration when instructed" do
-            subject.expects(:sleep).once.with(0.99)
+            subject.should_receive(:sleep).once.with(0.99)
             subject.play_tones("!950/330,!1400/330,!1800/330,0", true)
           end
         end
@@ -483,15 +483,15 @@ module Adhearsion::Asterisk
       describe "#play_soundfile" do
         let(:audiofile) { "tt-monkeys" }
         it "should send the correct command Playback playing an audio file" do
-          subject.expects(:execute).once.with("Playback", audiofile)
-          # subject.expects(:execute).once.with("Playback", audiofile).returns([200, 1, nil])
-          subject.expects(:get_variable).once.with("PLAYBACKSTATUS").returns(PLAYBACK_SUCCESS)
+          subject.should_receive(:execute).once.with("Playback", audiofile)
+          # subject.should_receive(:execute).once.with("Playback", audiofile).and_return([200, 1, nil])
+          subject.should_receive(:get_variable).once.with("PLAYBACKSTATUS").and_return(PLAYBACK_SUCCESS)
           subject.play_soundfile(audiofile)
         end
 
         it "should return false if playback fails" do
-          subject.expects(:execute).once.with("Playback", audiofile)
-          subject.expects(:get_variable).once.with("PLAYBACKSTATUS").returns('FAILED')
+          subject.should_receive(:execute).once.with("Playback", audiofile)
+          subject.should_receive(:get_variable).once.with("PLAYBACKSTATUS").and_return('FAILED')
           subject.play_soundfile(audiofile).should == false
         end
       end
@@ -500,7 +500,7 @@ module Adhearsion::Asterisk
         context 'executes Playtones with 0 as an argument if it' do
           before do
             command = Punchblock::Component::Asterisk::AGI::Command.new :name => "EXEC Playtones", :params => ["0"]
-            @expect_command = subject.expects(:execute_component_and_await_completion).with(command)
+            @expect_command = subject.should_receive(:execute_component_and_await_completion).with(command)
           end
 
           it 'is not given a block' do
@@ -509,7 +509,7 @@ module Adhearsion::Asterisk
           end
 
           it 'is given a block, which it then yields' do
-            @expect_command.times(3)
+            @expect_command.exactly(3).times
             expect { |b| subject.generate_silence { b.to_proc.call; run; run } }.to yield_with_no_args
           end
 
@@ -551,34 +551,37 @@ module Adhearsion::Asterisk
         let(:priority) { 1 }
 
         it "sets the call to not hangup after execution" do
-          call.expects(:[]=).with(:ahn_prevent_hangup, true)
-          subject.expects(:execute).with('Goto', context, extension, priority)
-          subject.expects(:agi).with("ASYNCAGI BREAK").at_most_once
+          call.should_receive(:[]=).with(:ahn_prevent_hangup, true)
+          subject.should_receive(:execute).with('Goto', context, extension, priority)
+          subject.should_receive(:set_variable).with('PUNCHBLOCK_END_ON_ASYNCAGI_BREAK', 'true').once
+          subject.should_receive(:agi).with("ASYNCAGI BREAK").at_most :once
           subject.goto(context, extension, priority)
         end
 
         it "releases control of the call using ASYNCAGI BREAK" do
-          call.expects(:[]=).with(:ahn_prevent_hangup, true).at_most_once
-          subject.expects(:execute).with('Goto', context, extension, priority).at_most_once
-          subject.expects(:agi).with("ASYNCAGI BREAK").once
+          call.should_receive(:[]=).with(:ahn_prevent_hangup, true).at_most :once
+          subject.should_receive(:execute).with('Goto', context, extension, priority).at_most :once
+          subject.should_receive(:set_variable).with('PUNCHBLOCK_END_ON_ASYNCAGI_BREAK', 'true').once
+          subject.should_receive(:agi).with("ASYNCAGI BREAK").once
           subject.goto(context, extension, priority)
         end
 
         context "number of arguments" do
           before :each do
-            call.expects(:[]=).with(:ahn_prevent_hangup, true).at_most_once
-            subject.expects(:agi).with("ASYNCAGI BREAK").at_most_once
+            call.should_receive(:[]=).with(:ahn_prevent_hangup, true).at_most :once
+            subject.should_receive(:set_variable).with('PUNCHBLOCK_END_ON_ASYNCAGI_BREAK', 'true').once
+            subject.should_receive(:agi).with("ASYNCAGI BREAK").at_most :once
           end
           it "executes Goto with 3 arguments when passed all 3" do
-            subject.expects(:execute).with('Goto', context, extension, priority)
+            subject.should_receive(:execute).with('Goto', context, extension, priority)
             subject.goto(context, extension, priority)
           end
           it "executes Goto with 2 arguments when passed 2" do
-            subject.expects(:execute).with('Goto', context, extension)
+            subject.should_receive(:execute).with('Goto', context, extension)
             subject.goto(context, extension)
           end
           it "executes Goto with 1 arguments when passed 1" do
-            subject.expects(:execute).with('Goto', context)
+            subject.should_receive(:execute).with('Goto', context)
             subject.goto(context)
           end
         end

--- a/spec/adhearsion/asterisk/config_generators/agents_spec.rb
+++ b/spec/adhearsion/asterisk/config_generators/agents_spec.rb
@@ -250,8 +250,8 @@ describe "AgentsConfigGeneratorTestHelper" do
 
   it "generated_config_has_pair() works properly with two pairs" do
     @agents = mock "A fake agents with just one pair"
-    @agents.expects(:conf).twice.returns("[general]\n\nqaz=qwerty\nagent => 1,2,3")
- 
+    @agents.should_receive(:conf).twice.and_return("[general]\n\nqaz=qwerty\nagent => 1,2,3")
+
     generated_config_has_pair(:qaz => "qwerty").should be true
     generated_config_has_pair(:foo => "bar").should be false
   end

--- a/spec/adhearsion/asterisk/config_generators/queues_spec.rb
+++ b/spec/adhearsion/asterisk/config_generators/queues_spec.rb
@@ -135,8 +135,8 @@ describe "The private, helper methods in QueueDefinition" do
 
   it '#boolean should convert a boolean into "yes" or "no"' do
     mock_of_properties = mock "mock of the properties instance variable of a QueueDefinition"
-    mock_of_properties.expects(:[]=).once.with("icanhascheezburger", "yes")
-    queue.expects(:properties).returns mock_of_properties
+    mock_of_properties.should_receive(:[]=).once.with("icanhascheezburger", "yes")
+    queue.should_receive(:properties).and_return mock_of_properties
     queue.send(:boolean, "icanhascheezburger" => true)
   end
 
@@ -148,39 +148,39 @@ describe "The private, helper methods in QueueDefinition" do
 
   it '#int should coerce a String into a Numeric if possible' do
     mock_of_properties = mock "mock of the properties instance variable of a QueueDefinition"
-    mock_of_properties.expects(:[]=).once.with("chimpanzee", 1337)
-    queue.expects(:properties).returns mock_of_properties
+    mock_of_properties.should_receive(:[]=).once.with("chimpanzee", 1337)
+    queue.should_receive(:properties).and_return mock_of_properties
     queue.send(:int, "chimpanzee" => "1337")
   end
 
   it '#string should add the argument directly to the properties' do
     mock_of_properties = mock "mock of the properties instance variable of a QueueDefinition"
-    mock_of_properties.expects(:[]=).once.with("eins", "zwei")
-    queue.expects(:properties).returns mock_of_properties
+    mock_of_properties.should_receive(:[]=).once.with("eins", "zwei")
+    queue.should_receive(:properties).and_return mock_of_properties
     queue.send(:string, "eins" => "zwei")
   end
 
   it '#one_of() should add its successful match to the properties attribute' do
     mock_properties = mock "mock of the properties instance variable of a QueueDefinition"
-    mock_properties.expects(:[]=).once.with(:doesnt_matter, 5)
-    queue.expects(:properties).once.returns mock_properties
+    mock_properties.should_receive(:[]=).once.with(:doesnt_matter, 5)
+    queue.should_receive(:properties).once.and_return mock_properties
     queue.send(:one_of, 1..100, :doesnt_matter => 5)
   end
 
   it "one_of() should convert booleans to yes/no" do
     mock_properties = mock "mock of the properties instance variable of a QueueDefinition"
-    mock_properties.expects(:[]=).once.with(:doesnt_matter, 'yes')
-    queue.expects(:properties).once.returns mock_properties
+    mock_properties.should_receive(:[]=).once.with(:doesnt_matter, 'yes')
+    queue.should_receive(:properties).once.and_return mock_properties
     queue.send(:one_of, [true, false, :strict], :doesnt_matter => true)
 
     mock_properties = mock "mock of the properties instance variable of a QueueDefinition"
-    mock_properties.expects(:[]=).once.with(:doesnt_matter, :strict)
-    queue.expects(:properties).once.returns mock_properties
+    mock_properties.should_receive(:[]=).once.with(:doesnt_matter, :strict)
+    queue.should_receive(:properties).once.and_return mock_properties
     queue.send(:one_of, [true, false, :strict], :doesnt_matter => :strict)
 
     mock_properties = mock "mock of the properties instance variable of a QueueDefinition"
-    mock_properties.expects(:[]=).once.with(:doesnt_matter, 'no')
-    queue.expects(:properties).once.returns mock_properties
+    mock_properties.should_receive(:[]=).once.with(:doesnt_matter, 'no')
+    queue.should_receive(:properties).once.and_return mock_properties
     queue.send(:one_of, [true, false, :strict], :doesnt_matter => false)
   end
 
@@ -315,7 +315,7 @@ describe "ConfigGeneratorTestHelper" do
     generated_config_has_pair(:foo => "bar").should be true
 
     @queues = mock "A fake queues with just one pair"
-    @queues.expects(:to_s).twice.returns("[general]\n\nqaz=qwerty\nagent => 1,2,3")
+    @queues.should_receive(:to_s).twice.and_return("[general]\n\nqaz=qwerty\nagent => 1,2,3")
     generated_config_has_pair(:qaz => "qwerty").should be true
     generated_config_has_pair(:foo => "bar").should be false
   end

--- a/spec/adhearsion/asterisk/config_manager_spec.rb
+++ b/spec/adhearsion/asterisk/config_manager_spec.rb
@@ -8,7 +8,7 @@ module ConfigurationManagerTestHelper
 
   def mock_config_manager_for(config_string)
     new_config_manager_with("bogus filename").tap do |manager|
-      File.expects(:open).returns config_string
+      File.should_receive(:open).and_return config_string
     end
   end
 

--- a/spec/adhearsion/asterisk/plugin_spec.rb
+++ b/spec/adhearsion/asterisk/plugin_spec.rb
@@ -4,7 +4,7 @@ module Adhearsion::Asterisk
   describe 'plugin loading' do
     before(:all) { Adhearsion::Plugin.init_plugins }
 
-    let(:mock_call) { stub_everything 'Call' }
+    let(:mock_call) { mock(:call).as_null_object }
 
     it 'should extend Adhearsion::CallController with Asterisk methods' do
       Adhearsion::CallController.new(mock_call).should respond_to :play_time

--- a/spec/adhearsion/asterisk/queue_proxy/agent_proxy_spec.rb
+++ b/spec/adhearsion/asterisk/queue_proxy/agent_proxy_spec.rb
@@ -5,7 +5,7 @@ module Adhearsion::Asterisk
     describe AgentProxy do
       let(:queue_name)  { 'foobar' }
       let(:mock_ee)     { mock 'Adhearsion::DialPlan::ExecutionEnvironment' }
-      let(:mock_queue)  { stub_everything 'QueueProxy', :environment => mock_ee, :name => queue_name }
+      let(:mock_queue)  { mock('QueueProxy', :environment => mock_ee, :name => queue_name).as_null_object }
 
       let(:agent_id) { 123 }
 
@@ -13,15 +13,15 @@ module Adhearsion::Asterisk
 
       it 'should properly retrieve metadata' do
         metadata_name = 'status'
-        mock_ee.expects(:variable).once.with("AGENT(#{agent_id}:#{metadata_name})")
+        mock_ee.should_receive(:variable).once.with("AGENT(#{agent_id}:#{metadata_name})")
         subject.send :agent_metadata, metadata_name
       end
 
       it '#logged_in? should return true if the "state" of an agent == LOGGEDIN' do
-        subject.expects(:agent_metadata).once.with('status').returns 'LOGGEDIN'
+        subject.should_receive(:agent_metadata).once.with('status').and_return 'LOGGEDIN'
         subject.logged_in?.should be true
 
-        subject.expects(:agent_metadata).once.with('status').returns 'LOGGEDOUT'
+        subject.should_receive(:agent_metadata).once.with('status').and_return 'LOGGEDOUT'
         subject.logged_in?.should_not be true
       end
 
@@ -32,55 +32,55 @@ module Adhearsion::Asterisk
       end
 
       it 'should pause an agent properly from a certain queue' do
-        mock_ee.expects(:get_variable).once.with("PQMSTATUS").returns "PAUSED"
-        mock_ee.expects(:execute).once.with("PauseQueueMember", queue_name, "Agent/#{agent_id}")
+        mock_ee.should_receive(:get_variable).once.with("PQMSTATUS").and_return "PAUSED"
+        mock_ee.should_receive(:execute).once.with("PauseQueueMember", queue_name, "Agent/#{agent_id}")
 
         subject.pause!.should be true
       end
 
       it 'should pause an agent properly from a certain queue and return false when the agent did not exist' do
-        mock_ee.expects(:get_variable).once.with("PQMSTATUS").returns "NOTFOUND"
-        mock_ee.expects(:execute).once.with("PauseQueueMember", queue_name, "Agent/#{agent_id}")
+        mock_ee.should_receive(:get_variable).once.with("PQMSTATUS").and_return "NOTFOUND"
+        mock_ee.should_receive(:execute).once.with("PauseQueueMember", queue_name, "Agent/#{agent_id}")
 
         subject.pause!.should be false
       end
 
       it 'should pause an agent globally properly' do
-        mock_ee.expects(:get_variable).once.with("PQMSTATUS").returns "PAUSED"
-        mock_ee.expects(:execute).once.with "PauseQueueMember", nil, "Agent/#{agent_id}"
+        mock_ee.should_receive(:get_variable).once.with("PQMSTATUS").and_return "PAUSED"
+        mock_ee.should_receive(:execute).once.with "PauseQueueMember", nil, "Agent/#{agent_id}"
 
         subject.pause! :everywhere => true
       end
 
       it 'should unpause an agent properly' do
-        mock_ee.expects(:get_variable).once.with("UPQMSTATUS").returns "UNPAUSED"
-        mock_ee.expects(:execute).once.with("UnpauseQueueMember", queue_name, "Agent/#{agent_id}")
+        mock_ee.should_receive(:get_variable).once.with("UPQMSTATUS").and_return "UNPAUSED"
+        mock_ee.should_receive(:execute).once.with("UnpauseQueueMember", queue_name, "Agent/#{agent_id}")
 
         subject.unpause!.should be true
       end
 
       it 'should unpause an agent globally properly' do
-        mock_ee.expects(:get_variable).once.with("UPQMSTATUS").returns "UNPAUSED"
-        mock_ee.expects(:execute).once.with("UnpauseQueueMember", nil, "Agent/#{agent_id}")
+        mock_ee.should_receive(:get_variable).once.with("UPQMSTATUS").and_return "UNPAUSED"
+        mock_ee.should_receive(:execute).once.with("UnpauseQueueMember", nil, "Agent/#{agent_id}")
 
         subject.unpause!(:everywhere => true).should be true
       end
 
       it 'should remove an agent properly' do
-        mock_ee.expects(:execute).once.with('RemoveQueueMember', queue_name, "Agent/#{agent_id}")
-        mock_ee.expects(:get_variable).once.with("RQMSTATUS").returns "REMOVED"
+        mock_ee.should_receive(:execute).once.with('RemoveQueueMember', queue_name, "Agent/#{agent_id}")
+        mock_ee.should_receive(:get_variable).once.with("RQMSTATUS").and_return "REMOVED"
         subject.remove!.should be true
       end
 
       it 'should remove an agent properly' do
-        mock_ee.expects(:execute).once.with('RemoveQueueMember', queue_name, "Agent/#{agent_id}")
-        mock_ee.expects(:get_variable).once.with("RQMSTATUS").returns "NOTINQUEUE"
+        mock_ee.should_receive(:execute).once.with('RemoveQueueMember', queue_name, "Agent/#{agent_id}")
+        mock_ee.should_receive(:get_variable).once.with("RQMSTATUS").and_return "NOTINQUEUE"
         subject.remove!.should be false
       end
 
       it "should raise a QueueDoesNotExistError when removing an agent from a queue that doesn't exist" do
-        mock_ee.expects(:execute).once.with("RemoveQueueMember", queue_name, "Agent/#{agent_id}")
-        mock_ee.expects(:get_variable).once.with("RQMSTATUS").returns "NOSUCHQUEUE"
+        mock_ee.should_receive(:execute).once.with("RemoveQueueMember", queue_name, "Agent/#{agent_id}")
+        mock_ee.should_receive(:get_variable).once.with("RQMSTATUS").and_return "NOSUCHQUEUE"
         lambda {
           subject.remove!
         }.should raise_error QueueDoesNotExistError

--- a/spec/adhearsion/asterisk/queue_proxy/queue_agents_list_proxy_spec.rb
+++ b/spec/adhearsion/asterisk/queue_proxy/queue_agents_list_proxy_spec.rb
@@ -6,27 +6,27 @@ module Adhearsion::Asterisk
       let(:queue_name)    { 'foobar' }
       let(:agent_channel) { "Agent/123" }
       let(:mock_ee)       { mock 'Adhearsion::DialPlan::ExecutionEnvironment' }
-      let(:mock_queue)    { stub_everything 'QueueProxy', :environment => mock_ee, :name => queue_name }
+      let(:mock_queue)    { mock('QueueProxy', :environment => mock_ee, :name => queue_name).as_null_object }
 
       subject { QueueAgentsListProxy.new mock_queue, true }
 
       it 'should fetch the members with the queue name' do
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_COUNT(#{queue_name})").returns 5
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_COUNT(#{queue_name})").and_return 5
         subject.size.should == 5
       end
 
       it 'should not fetch a QUEUE_MEMBER_COUNT each time #count is called when caching is enabled' do
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_COUNT(#{queue_name})").returns 0
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_COUNT(#{queue_name})").and_return 0
         10.times { subject.size }
       end
 
       it 'when fetching agents, it should properly split by the supported delimiters' do
-        mock_ee.expects(:get_variable).with("QUEUE_MEMBER_LIST(#{queue_name})").returns('Agent/007,Agent/003,Zap/2')
+        mock_ee.should_receive(:get_variable).with("QUEUE_MEMBER_LIST(#{queue_name})").and_return('Agent/007,Agent/003,Zap/2')
         subject.to_a.size.should == 3
       end
 
       it 'when fetching agents, each array index should be an instance of AgentProxy' do
-        mock_ee.expects(:get_variable).with("QUEUE_MEMBER_LIST(#{queue_name})").returns('Agent/007,Agent/003,Zap/2')
+        mock_ee.should_receive(:get_variable).with("QUEUE_MEMBER_LIST(#{queue_name})").and_return('Agent/007,Agent/003,Zap/2')
         agents = subject.to_a
         agents.size.should > 0
         agents.each do |agent|
@@ -35,30 +35,30 @@ module Adhearsion::Asterisk
       end
 
       it '#<< should new the channel driver given as the argument to the system' do
-        mock_ee.expects(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
-        mock_ee.expects(:get_variable).once.with('AQMSTATUS').returns('ADDED')
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").returns "Agent/007,SIP/2302,Local/2510@from-internal"
+        mock_ee.should_receive(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
+        mock_ee.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
         subject.new agent_channel
       end
 
       it 'when a queue agent is dynamically added and the queue does not exist, a QueueDoesNotExistError should be raised' do
-        mock_ee.expects(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
-        mock_ee.expects(:get_variable).once.with('AQMSTATUS').returns('NOSUCHQUEUE')
+        mock_ee.should_receive(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
+        mock_ee.should_receive(:get_variable).once.with('AQMSTATUS').and_return('NOSUCHQUEUE')
         lambda {
           subject.new agent_channel
         }.should raise_error QueueDoesNotExistError
       end
 
       it 'when a queue agent is dynamiaclly added and the adding was successful, an AgentProxy should be returned' do
-        mock_ee.expects(:get_variable).once.with("AQMSTATUS").returns("ADDED")
-        mock_ee.expects(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").returns "Agent/007,SIP/2302,Local/2510@from-internal"
+        mock_ee.should_receive(:get_variable).once.with("AQMSTATUS").and_return("ADDED")
+        mock_ee.should_receive(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
         subject.new(agent_channel).should be_a AgentProxy
       end
 
       it 'when a queue agent is dynamiaclly added and the adding was unsuccessful, a false should be returned' do
-        mock_ee.expects(:get_variable).once.with("AQMSTATUS").returns("MEMBERALREADY")
-        mock_ee.expects(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
+        mock_ee.should_receive(:get_variable).once.with("AQMSTATUS").and_return("MEMBERALREADY")
+        mock_ee.should_receive(:execute).once.with("AddQueueMember", queue_name, agent_channel, "", "", "", "")
         subject.new(agent_channel).should be false
       end
 
@@ -69,61 +69,61 @@ module Adhearsion::Asterisk
       end
 
       it 'should execute AddQueueMember with the penalty properly' do
-        mock_ee.expects(:execute).once.with('AddQueueMember', queue_name, agent_channel, 10, '', '','')
-        mock_ee.expects(:get_variable).once.with('AQMSTATUS').returns('ADDED')
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").returns "Agent/007,SIP/2302,Local/2510@from-internal"
+        mock_ee.should_receive(:execute).once.with('AddQueueMember', queue_name, agent_channel, 10, '', '','')
+        mock_ee.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
         subject.new agent_channel, :penalty => 10
       end
 
       it 'should execute AddQueueMember with the state_interface properly' do
-        mock_ee.expects(:execute).once.with('AddQueueMember', queue_name, agent_channel, '', '', '','SIP/2302')
-        mock_ee.expects(:get_variable).once.with('AQMSTATUS').returns('ADDED')
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").returns "Agent/007,SIP/2302,Local/2510@from-internal"
+        mock_ee.should_receive(:execute).once.with('AddQueueMember', queue_name, agent_channel, '', '', '','SIP/2302')
+        mock_ee.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
         subject.new agent_channel, :state_interface => 'SIP/2302'
       end
 
       it 'should execute AddQueueMember properly when the name is given' do
         agent_name = 'Jay Phillips'
-        mock_ee.expects(:execute).once.with('AddQueueMember', queue_name, agent_channel, '', '', agent_name,'')
-        mock_ee.expects(:get_variable).once.with('AQMSTATUS').returns('ADDED')
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").returns "Agent/007,SIP/2302,Local/2510@from-internal"
+        mock_ee.should_receive(:execute).once.with('AddQueueMember', queue_name, agent_channel, '', '', agent_name,'')
+        mock_ee.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
         subject.new agent_channel, :name => agent_name
       end
 
       it 'should execute AddQueueMember properly when the name, penalty, and interface is given' do
         agent_name, penalty = 'Jay Phillips', 4
-        mock_ee.expects(:execute).once.with('AddQueueMember', queue_name, agent_channel, penalty, '', agent_name,'')
-        mock_ee.expects(:get_variable).once.with('AQMSTATUS').returns('ADDED')
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").returns "Agent/007,SIP/2302,Local/2510@from-internal"
+        mock_ee.should_receive(:execute).once.with('AddQueueMember', queue_name, agent_channel, penalty, '', agent_name,'')
+        mock_ee.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
         subject.new agent_channel, :name => agent_name, :penalty => penalty
       end
 
       it 'should execute AddQueueMember properly when the name, penalty, interface, and state_interface is given' do
         agent_name, penalty, state_interface = 'Jay Phillips', 4, 'SIP/2302'
-        mock_ee.expects(:execute).once.with('AddQueueMember', queue_name, agent_channel, penalty, '', agent_name, state_interface)
-        mock_ee.expects(:get_variable).once.with('AQMSTATUS').returns('ADDED')
-        mock_ee.expects(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").returns "Agent/007,SIP/2302,Local/2510@from-internal"
+        mock_ee.should_receive(:execute).once.with('AddQueueMember', queue_name, agent_channel, penalty, '', agent_name, state_interface)
+        mock_ee.should_receive(:get_variable).once.with('AQMSTATUS').and_return('ADDED')
+        mock_ee.should_receive(:get_variable).once.with("QUEUE_MEMBER_LIST(#{queue_name})").and_return "Agent/007,SIP/2302,Local/2510@from-internal"
         subject.new agent_channel, :name => agent_name, :penalty => penalty, :state_interface => state_interface
       end
 
       it "should log an agent in properly with no agent id given" do
-        mock_ee.expects(:execute).once.with('AgentLogin', nil, 's')
+        mock_ee.should_receive(:execute).once.with('AgentLogin', nil, 's')
         subject.login!
       end
 
       it 'should remove "Agent/" before the agent ID given if necessary when logging an agent in' do
-        mock_ee.expects(:execute).once.with('AgentLogin', '007', 's')
+        mock_ee.should_receive(:execute).once.with('AgentLogin', '007', 's')
         subject.login! 'Agent/007'
 
-        mock_ee.expects(:execute).once.with('AgentLogin', '007', 's')
+        mock_ee.should_receive(:execute).once.with('AgentLogin', '007', 's')
         subject.login! '007'
       end
 
       it 'should add an agent silently properly' do
-        mock_ee.expects(:execute).once.with('AgentLogin', '007', '')
+        mock_ee.should_receive(:execute).once.with('AgentLogin', '007', '')
         subject.login! 'Agent/007', :silent => false
 
-        mock_ee.expects(:execute).once.with('AgentLogin', '008', 's')
+        mock_ee.should_receive(:execute).once.with('AgentLogin', '008', 's')
         subject.login! 'Agent/008', :silent => true
       end
 

--- a/spec/adhearsion/asterisk/queue_proxy_spec.rb
+++ b/spec/adhearsion/asterisk/queue_proxy_spec.rb
@@ -19,82 +19,82 @@ module Adhearsion::Asterisk
 
     describe '#join' do
       it 'should properly join a queue' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "FULL"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "FULL"
         subject.join!
       end
 
       it 'should return a symbol representing the result of joining the queue' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "TIMEOUT"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "TIMEOUT"
         subject.join!.should be :timeout
       end
 
       it 'should return :completed after joining the queue and being connected' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns nil
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return nil
         subject.join!.should be :completed
       end
 
       it 'should join a queue with a timeout properly' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "", '', '', '60', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "", '', '', '60', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :timeout => 1.minute
       end
 
       it 'should join a queue with an announcement file properly' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "", '', 'custom_announcement_file_here', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "", '', 'custom_announcement_file_here', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :announce => 'custom_announcement_file_here'
       end
 
       it 'should join a queue with an agi script properly' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, '', '', '', '','agi://localhost/queue_agi_test')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINUNAVAIL"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, '', '', '', '','agi://localhost/queue_agi_test')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINUNAVAIL"
         subject.join! :agi => 'agi://localhost/queue_agi_test'
       end
 
       it 'should join a queue with allow_transfer properly' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "Tt", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "Tt", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :allow_transfer => :everyone
 
-        mock_ee.expects(:execute).once.with("queue", queue_name, "T", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "T", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :allow_transfer => :caller
 
-        mock_ee.expects(:execute).once.with("queue", queue_name, "t", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "t", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :allow_transfer => :agent
       end
 
       it 'should join a queue with allow_hangup properly' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "Hh", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "Hh", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :allow_hangup => :everyone
 
-        mock_ee.expects(:execute).once.with("queue", queue_name, "H", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "H", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :allow_hangup => :caller
 
-        mock_ee.expects(:execute).once.with("queue", queue_name, "h", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "h", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :allow_hangup => :agent
       end
 
       it 'should join a queue properly with the :play argument' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "r", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "r", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :play => :ringing
 
-        mock_ee.expects(:execute).once.with("queue", queue_name, "", '', '', '', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "", '', '', '', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :play => :music
       end
 
       it 'joining a queue with many options specified' do
-        mock_ee.expects(:execute).once.with("queue", queue_name, "rtHh", '', '', '120', '')
-        mock_ee.expects(:get_variable).once.with("QUEUESTATUS").returns "JOINEMPTY"
+        mock_ee.should_receive(:execute).once.with("queue", queue_name, "rtHh", '', '', '120', '')
+        mock_ee.should_receive(:get_variable).once.with("QUEUESTATUS").and_return "JOINEMPTY"
         subject.join! :allow_transfer => :agent, :timeout => 2.minutes,
                       :play => :ringing, :allow_hangup => :everyone
       end
@@ -115,41 +115,41 @@ module Adhearsion::Asterisk
     end
 
     it 'should return a correct boolean for #exists?' do
-      mock_ee.expects(:execute).once.with("RemoveQueueMember", queue_name, "SIP/AdhearsionQueueExistenceCheck")
-      mock_ee.expects(:get_variable).once.with("RQMSTATUS").returns "NOTINQUEUE"
+      mock_ee.should_receive(:execute).once.with("RemoveQueueMember", queue_name, "SIP/AdhearsionQueueExistenceCheck")
+      mock_ee.should_receive(:get_variable).once.with("RQMSTATUS").and_return "NOTINQUEUE"
       subject.exists?.should be true
 
-      mock_ee.expects(:execute).once.with("RemoveQueueMember", queue_name, "SIP/AdhearsionQueueExistenceCheck")
-      mock_ee.expects(:get_variable).once.with("RQMSTATUS").returns "NOSUCHQUEUE"
+      mock_ee.should_receive(:execute).once.with("RemoveQueueMember", queue_name, "SIP/AdhearsionQueueExistenceCheck")
+      mock_ee.should_receive(:get_variable).once.with("RQMSTATUS").and_return "NOSUCHQUEUE"
       subject.exists?.should be false
     end
 
     it 'waiting_count for a queue that does exist' do
-      mock_ee.expects(:get_variable).once.with("QUEUE_WAITING_COUNT(#{queue_name})").returns "50"
-      subject.expects(:exists?).once.returns true
+      mock_ee.should_receive(:get_variable).once.with("QUEUE_WAITING_COUNT(#{queue_name})").and_return "50"
+      subject.should_receive(:exists?).once.and_return true
       subject.waiting_count.should == 50
     end
 
     it 'waiting_count for a queue that does not exist' do
       lambda {
-        subject.expects(:exists?).once.returns false
+        subject.should_receive(:exists?).once.and_return false
         subject.waiting_count
       }.should raise_error Adhearsion::Asterisk::QueueProxy::QueueDoesNotExistError
     end
 
     it 'empty? should call waiting_count' do
-      subject.expects(:waiting_count).once.returns 0
+      subject.should_receive(:waiting_count).once.and_return 0
       subject.empty?.should be true
 
-      subject.expects(:waiting_count).once.returns 99
+      subject.should_receive(:waiting_count).once.and_return 99
       subject.empty?.should_not be true
     end
 
     it 'any? should call waiting_count' do
-      subject.expects(:waiting_count).once.returns 0
+      subject.should_receive(:waiting_count).once.and_return 0
       subject.any?.should be false
 
-      subject.expects(:waiting_count).once.returns 99
+      subject.should_receive(:waiting_count).once.and_return 99
       subject.any?.should be true
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,12 +12,10 @@ SimpleCov.start do
 end
 
 require 'adhearsion/asterisk'
-require 'mocha'
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  config.mock_with :mocha
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
This includes the change to set PUNCHBLOCK_END_ON_ASYNCAGI_BREAK when executing Goto.

The specs have been updated to remove mocha and use rspec mocks since test execution was hanging with mocha.
