### PR TITLE
Update play_time to explicitly send the default time format. Older aster...

### DIFF
--- a/lib/adhearsion/asterisk/call_controller_methods.rb
+++ b/lib/adhearsion/asterisk/call_controller_methods.rb
@@ -352,6 +352,7 @@ module Adhearsion
                      format = 'BdY' unless format.present?
                      argument.to_time.to_i
                    end
+        format = "ABdY \'digits/at\' IMp" if format.empty?
 
         return false if epoch.nil?
 

--- a/spec/adhearsion/asterisk/call_controller_methods_spec.rb
+++ b/spec/adhearsion/asterisk/call_controller_methods_spec.rb
@@ -437,7 +437,7 @@ module Adhearsion::Asterisk
         end
 
         it "if a Time object is passed in alone, SayUnixTime is sent with the argument and the default format" do
-          subject.should_receive(:execute).once.with("SayUnixTime", time.to_i, "", "")
+          subject.should_receive(:execute).once.with("SayUnixTime", time.to_i, "", "ABdY \'digits/at\' IMp")
           subject.play_time(time)
         end
 


### PR DESCRIPTION
...isk versions won't handle dangling nil arguments.
