### PR TITLE
Gemspec: drop rubyforge_project property

### DIFF
--- a/adhearsion-asterisk.gemspec
+++ b/adhearsion-asterisk.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Asterisk specific features for Adhearsion}
   s.description = %q{An Adhearsion Plugin providing Asterisk-specific dialplan methods, AMI access, and access to Asterisk configuration}
 
-  s.rubyforge_project = "adhearsion-asterisk"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

RubyForge was closed down in 2013 [1]. The `rubyforge_project` property
was deprecated in rubygems in pull request 2436 [2].

[1] https://twitter.com/evanphx/status/399552820380053505
[2] rubygems/rubygems#2436